### PR TITLE
Fix for SSL certificate error #2011

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -1164,7 +1164,10 @@ const internalCertificate = {
 				method:  'POST',
 				headers: {
 					'Content-Type':   'application/x-www-form-urlencoded',
-					'Content-Length': Buffer.byteLength(formBody)
+					'Content-Length': Buffer.byteLength(formBody),
+					'Connection': 'keep-alive',
+					'User-Agent': 'Nginx Proxy Manager',
+					'Accept': '*/*'
 				}
 			};
 
@@ -1175,12 +1178,16 @@ const internalCertificate = {
 
 					res.on('data', (chunk) => responseBody = responseBody + chunk);
 					res.on('end', function () {
-						const parsedBody = JSON.parse(responseBody + '');
-						if (res.statusCode !== 200) {
+						try {
+							const parsedBody = JSON.parse(responseBody + '');
+							resolve(parsedBody);
+						}
+						catch {
+							logger.warn("Error");
+							logger.warn(`Status Code: ${res.statusCode}`);
 							logger.warn(`Failed to test HTTP challenge for domain ${domain}`, res);
 							resolve(undefined);
 						}
-						resolve(parsedBody);
 					});
 				});
 


### PR DESCRIPTION
- Keepalive, User Agent + Accept headers
- Catch added for failed JSON parsing
- More accurate errors displayed to user