### PR TITLE
Add healthcheck to compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,10 @@ services:
     container_name: npmplus
     image: zoeyvid/npmplus
     restart: always
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/healthcheck.sh"]
+      interval: 10s
+      timeout: 3s
     network_mode: host
     volumes:
       - "/opt/npm:/data"


### PR DESCRIPTION
When switching over from original nginx-proxy-manager, my healthcheck started failing (because the path differs). Prevent this by having the correct healthcheck in the example compose file.