### PR TITLE
Mention healthcheck when migrating in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ so that the barrier for entry here is low.
 - some buttons have changed, check if they are still correct
 - please delete all dnspod certs and recreate them OR you manually change the credentialsfile (see [here](https://github.com/ZoeyVid/npmplus/blob/develop/global/certbot-dns-plugins.js) for the template)
 - since this fork has dependency on `network_mode: host`, please don't forget to open port 80 and 443 (and maybe 81) in your firewall
+- if you have a healthcheck defined in your compose yaml file, remove it - this fork defines its own healthcheck in the Dockerfile, so you don't need to have it in compose anymore
 
 # Crowdsec
 1. Install crowdsec using this compose file: https://github.com/ZoeyVid/NPMplus/blob/develop/compose.crowdsec.yaml


### PR DESCRIPTION
To avoid reporting the container as unhealthy after migrating from original NPM, warn users in the README