### PR TITLE
pkill of go/access + definable pause between LogRotate Runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,6 +155,7 @@ ENV ACME_SERVER="https://acme-v02.api.letsencrypt.org/directory" \
     SKIP_IP_RANGES=false \
     LOGROTATE=false \
     LOGROTATIONS=3 \
+    LOGROTATEDELAY=25h \
     CRT=24 \
     IPRT=1 \
     GOA=false \

--- a/compose.yaml
+++ b/compose.yaml
@@ -43,6 +43,7 @@ services:
 #      - "SKIP_IP_RANGES=true" # Skip feteching/whitelisting ip ranges from aws and cloudflare, default false
 #      - "LOGROTATE=true" # Enables writing http access logs to /opt/npm/nginx/access.log, stream access logs to /opt/npm/nginx/stream.log and enables daily logrotation, default false
 #      - "LOGROTATIONS=7" # Set how often the access.log should be rotated until it is deleted, default 3
+#      - "LOGROTATEDELAY=25h" # Set the time to wait between running log rotations, default 25 hours. NB this will still only run once a day.
 #      - "CRT=36" # Set how many hours should be between certbot trying to renew your certs, default 24
 #      - "IPRT=3" # Set how many hours should be between updating ip ranges from aws and cloudflare, default 1, ignored when SKIP_IP_RANGES is true
 #      - "GOA=true" # Enables goaccess, requires LOGROTATE, default false --- if you download the GeoLite2-Country.mmdb, GeoLite2-City.mmdb AND GeoLite2-ASN.mmdb file from MaxMind and place them in /opt/npm/etc/goaccess/geoip it will automatically enable GeoIP in goaccess after restarting NPMplus (no need to change GOACLA below), you may also use the compose.geoip.yaml

--- a/rootfs/etc/logrotate
+++ b/rootfs/etc/logrotate
@@ -5,8 +5,10 @@
         notifempty
         compress
         sharedscripts
+        prerotate
+            pkill goaccess
+        endscript
         postrotate
             if [ -s /usr/local/nginx/logs/nginx.pid ]; then nginx -s reload; fi
-            kill "$(pgrep goaccess)"
         endscript
 }

--- a/rootfs/usr/local/bin/launch.sh
+++ b/rootfs/usr/local/bin/launch.sh
@@ -73,8 +73,7 @@ fi
 
 if [ "$PHP82" = "true" ]; then PHP_INI_SCAN_DIR=/data/php/82/conf.d php-fpm82 -c /data/php/82 -y /data/php/82/php-fpm.conf -FOR; fi &
 if [ "$PHP83" = "true" ]; then PHP_INI_SCAN_DIR=/data/php/83/conf.d php-fpm83 -c /data/php/83 -y /data/php/83/php-fpm.conf -FOR; fi &
-if [ "$LOGROTATE" = "true" ] && [ "$GOA" = "false" ]; then sleep 1m; while true; do logrotate --verbose --state /data/etc/logrotate.status /etc/logrotate; sleep 25h; done; fi &
-if [ "$LOGROTATE" = "true" ] && [ "$GOA" = "true" ]; then sleep 1m; while true; do killall goaccess; sleep 10s; logrotate --verbose --state /data/etc/logrotate.status /etc/logrotate; sleep 25h; done; fi &
+if [ "$LOGROTATE" = "true" ]; then while true; do sleep $LOGROTATEDELAY; logrotate --verbose --state /data/etc/logrotate.status /etc/logrotate; done; fi &
 # shellcheck disable=SC2086
 if [ "$GOA" = "true" ]; then while true; do goaccess --no-global-config --num-tests=0 --tz="$TZ" --date-format="%d/%b/%Y" --time-format="%H:%M:%S" --log-format='[%d:%t %^] %v %h %T "%r" %s %b %b %R %u' --no-ip-validation --addr=127.0.0.1 --port="$GOAIWSP" \
                                 -f /data/nginx/access.log --real-time-html -o /tmp/goa/index.html --persist --restore --db-path=/data/etc/goaccess/data -b /etc/goaccess/browsers.list -b /etc/goaccess/podcast.list $GOACLA; done; fi &

--- a/rootfs/usr/local/bin/launch.sh
+++ b/rootfs/usr/local/bin/launch.sh
@@ -75,7 +75,7 @@ if [ "$PHP82" = "true" ]; then PHP_INI_SCAN_DIR=/data/php/82/conf.d php-fpm82 -c
 if [ "$PHP83" = "true" ]; then PHP_INI_SCAN_DIR=/data/php/83/conf.d php-fpm83 -c /data/php/83 -y /data/php/83/php-fpm.conf -FOR; fi &
 if [ "$LOGROTATE" = "true" ]; then while true; do sleep $LOGROTATEDELAY; logrotate --verbose --state /data/etc/logrotate.status /etc/logrotate; done; fi &
 # shellcheck disable=SC2086
-if [ "$GOA" = "true" ]; then while true; do goaccess --no-global-config --num-tests=0 --tz="$TZ" --date-format="%d/%b/%Y" --time-format="%H:%M:%S" --log-format='[%d:%t %^] %v %h %T "%r" %s %b %b %R %u' --no-ip-validation --addr=127.0.0.1 --port="$GOAIWSP" \
+if [ "$GOA" = "true" ]; then while true; do sleep 15s; goaccess --no-global-config --num-tests=0 --tz="$TZ" --date-format="%d/%b/%Y" --time-format="%H:%M:%S" --log-format='[%d:%t %^] %v %h %T "%r" %s %b %b %R %u' --no-ip-validation --addr=127.0.0.1 --port="$GOAIWSP" \
                                 -f /data/nginx/access.log --real-time-html -o /tmp/goa/index.html --persist --restore --db-path=/data/etc/goaccess/data -b /etc/goaccess/browsers.list -b /etc/goaccess/podcast.list $GOACLA; done; fi &
 aio.sh &
 index.js

--- a/rootfs/usr/local/bin/start.sh
+++ b/rootfs/usr/local/bin/start.sh
@@ -246,6 +246,11 @@ if [ -n "$LOGROTATE" ] && ! echo "$LOGROTATIONS" | grep -q "^[0-9]\+$"; then
     sleep inf
 fi
 
+if [ -n "$LOGROTATEDELAY" ] && ! echo "$LOGROTATEDELAY" | grep -Pq "^(0?[1-9]|1[0-9]|2[0-5])h"; then
+    echo "LOGOROTATEDELAY needs to be a value between 1h and 25h."
+    sleep inf
+fi
+
 if ! echo "$CRT" | grep -q "^[0-9]\+$"; then
     echo "CRT needs to be a number."
     sleep inf


### PR DESCRIPTION
Move sleep command to start of logrotate line so it doesn't run the moment you start the service.
New ENV Var LOGROTATEDELAY with a default value of 25h lets you change the pause before the 1st and each subsequent run of logrotate. NB logrotate still only runs once every 24 hrs (daily setting in logrotate config). I've been using at 3h in my dev environment with no issues.
Move kill of gorotate from the launch.sh to the logrotate config in "perorate" so that the db files of goaccess are updated before the logs are rotated. (use pkill as most efficient way of killing only if service is running)