### PR TITLE
Fix double slashes // in end of path.

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -4,7 +4,7 @@
 {% if path != "/" and path_first_char == "/" and path_last_char == "/" %}
 location {{ path | remove_last: "/" }} {
     absolute_redirect off;
-    return 301 {{ path }}/;
+    return 301 {{ path }};
 }
 {% endif %}
 


### PR DESCRIPTION
Fix double slashes // in end of path.

Remove the / because there has been / in the last char of path.

Example of bug:
>   location /speedtest {
>       absolute_redirect off;
>       return 301 /speedtest<mark>//</mark>;
>   }


