### PR TITLE
Update nginx.conf

### DIFF
--- a/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/rootfs/usr/local/nginx/conf/nginx.conf
@@ -250,7 +250,7 @@ stream {
     ssl_preread on;
     ssl_session_timeout 1d;
     ssl_session_cache shared:TLS:10m;
-    ssl_dhparam ffdhe4096.pem
+    ssl_dhparam ffdhe4096.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ecdh_curve SecP384r1MLKEM1024:X25519MLKEM768:SecP256r1MLKEM768:x25519:x448:secp521r1:secp384r1:secp256r1;
     ssl_prefer_server_ciphers on;


### PR DESCRIPTION
Fix Failure of:

nginx: [emerg] invalid number of arguments in "ssl_dhparam" directive in /usr/local/nginx/conf/nginx.conf:254
nginx: configuration file /usr/local/nginx/conf/nginx.conf test failed