### PR TITLE
Switch to ghcr.io as image registry for geoipupdate

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -102,7 +102,7 @@ services:
 # This can be used with GOA=true, to keep the geopip database updated, you need to change the envs to make it work
 #  geoipupdate:
 #    container_name: npmplus-geoipupdate
-#    image: docker.io/maxmindinc/geoipupdate:latest
+#    image: docker.io/maxmindinc/geoipupdate:latest  # or ghcr.io/maxmind/geoipupdate:latest
 #    restart: always
 #    network_mode: bridge
 #    environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -102,7 +102,7 @@ services:
 # This can be used with GOA=true, to keep the geopip database updated, you need to change the envs to make it work
 #  geoipupdate:
 #    container_name: npmplus-geoipupdate
-#    image: docker.io/maxmindinc/geoipupdate:latest  # or ghcr.io/maxmind/geoipupdate:latest
+#    image: ghcr.io/maxmind/geoipupdate:latest
 #    restart: always
 #    network_mode: bridge
 #    environment:


### PR DESCRIPTION
According to the GeoIPUpdate DockerHub page, ghcr.io should be used to obtain new image releases (see https://hub.docker.com/r/maxmindinc/geoipupdate#new-versions-of-geoipupdate-will-be-distributed-on-ghcrio).