### PR TITLE
Add USE_WAL optional env variable for crowdsec

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -101,6 +101,7 @@ services:
 #    environment:
 #      - "TZ=your-timezone" # needs to be changed
 #      - "COLLECTIONS=ZoeyVid/npmplus"
+#.     - "USE_WAL=true" # optional, enables write ahead logging for better performance, may cause higher disk usage, default false
 #    volumes:
 #      - "/opt/crowdsec/conf:/etc/crowdsec"
 #      - "/opt/crowdsec/data:/var/lib/crowdsec/data"


### PR DESCRIPTION
USE_WAL optional env variable for crowdsec enabling write ahead logging for better performance, may cause higher disk usage, default false.

#2257 

Crowdsec container would warn `sqlite is not using WAL mode, LAPI might become unresponsive when inserting the community blocklist`.
