### PR TITLE
fix: remove duplicate advanced_config from proxy_host templates

### DIFF
--- a/backend/templates/_common.conf
+++ b/backend/templates/_common.conf
@@ -65,5 +65,3 @@ location /.well-known/acme-challenge/ {
 location ~* /\.ht {
     return 403;
 }
-
-{{ advanced_config }}

--- a/backend/templates/dead_host.conf
+++ b/backend/templates/dead_host.conf
@@ -13,6 +13,9 @@
         try_files $uri =404;
       }
     {% endif %}
+
+    {{ advanced_config }}
+
     # Custom
     include /data/custom_nginx/server_dead.conf;
   }

--- a/backend/templates/redirection_host.conf
+++ b/backend/templates/redirection_host.conf
@@ -9,6 +9,9 @@
     {% if use_default_location %}
       location / { return {{ forward_http_code }} {{ forward_scheme }}://{{ forward_domain_name }}{% if preserve_path %}$request_uri{% endif %}; }
     {% endif %}
+
+    {{ advanced_config }}
+
     # Custom
     include /data/custom_nginx/server_redirect.conf;
   }


### PR DESCRIPTION
## Summary

The `{{ advanced_config }}` variable was being inserted twice in proxy_host configurations, causing nginx config validation failures.

## Problem

After the template refactoring in 8b2bc284, `advanced_config` appears in two places:
1. `_common.conf` line 69 (included early in the server block)
2. `proxy_host.conf` line 78 (after custom locations)

This causes errors like:
- `nginx: [emerg] duplicate "client_max_body_size" directive`
- `nginx: [emerg] duplicate location "/some/path"`

Any proxy host with custom location blocks or certain directives in advanced_config will fail to validate.

## Fix

- Remove `{{ advanced_config }}` from `_common.conf`
- Add it explicitly to `dead_host.conf` and `redirection_host.conf` (which relied on `_common.conf` for it)
- `proxy_host.conf` already has it in the correct position

## Testing

Tested with proxy hosts containing custom location blocks in advanced_config. Nginx config now validates successfully and the container reports healthy.