### PR TITLE
changed default ACME_PROFILE to classic

### DIFF
--- a/rootfs/usr/local/bin/envs.sh
+++ b/rootfs/usr/local/bin/envs.sh
@@ -58,7 +58,7 @@ export ACME_SERVER="${ACME_SERVER:-https://acme-v02.api.letsencrypt.org/director
 
 case "$ACME_SERVER" in
     "https://acme-v02.api.letsencrypt.org/directory")
-        export ACME_PROFILE="${ACME_PROFILE:-shortlived}"
+        export ACME_PROFILE="${ACME_PROFILE:-classic}"
         ;;
 
     "https://dv.acme-v02.api.pki.goog/directory")


### PR DESCRIPTION
Hi,
I recently switched (late January) to your version of NPM and noticed that the certificates are being updated, but their expiration dates are set too close together (6–7 days after renewal).
After looking into the issue, I found that the default ACME profile is set to “shortlived,” so the certificates only last 7 days. If possible, please push this change to the master/main branch.

I hope I’m not being too rude by jumping right into your code like this.

Fabio