### PR TITLE
Correct directadmin full_plugin_name to dns-directadmin

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -109,7 +109,7 @@
 	},
 	"directadmin": {
 		"credentials": "directadmin_url = https://my.directadminserver.com:2222\ndirectadmin_username = username\ndirectadmin_password = aSuperStrongPassword",
-		"full_plugin_name": "directadmin",
+		"full_plugin_name": "dns-directadmin",
 		"name": "DirectAdmin",
 		"package_name": "certbot-dns-directadmin"
 	},


### PR DESCRIPTION
The full_plugin_name for the DirectAdmin DNS plugin was set to "directadmin",
  but the certbot plugin (certbot-dns-directadmin) registers its entry point as
  "dns-directadmin" in its pyproject.toml.

  This caused certbot to be called with:
  --authenticator directadmin --directadmin-credentials /tmp/...

  Which results in:
  certbot: error: unrecognized arguments: --directadmin-credentials

  Changing full_plugin_name to "dns-directadmin" fixes the generated command:
  --authenticator dns-directadmin --dns-directadmin-credentials /tmp/...