### PR TITLE
Correct directadmin credentials key names to use dns_directadmin_ prefix

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -109,7 +109,7 @@
 	},
 	"directadmin": {
 		"credentials": "directadmin_url = https://my.directadminserver.com:2222\ndirectadmin_username = username\ndirectadmin_password = aSuperStrongPassword",
-		"full_plugin_name": "directadmin",
+		"full_plugin_name": "dns-directadmin",
 		"name": "DirectAdmin",
 		"package_name": "certbot-dns-directadmin"
 	},

--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -108,7 +108,7 @@
 		"package_name": "certbot-dns-digitalocean"
 	},
 	"directadmin": {
-		"credentials": "directadmin_url = https://my.directadminserver.com:2222\ndirectadmin_username = username\ndirectadmin_password = aSuperStrongPassword",
+		"credentials": "dns_directadmin_url = https://my.directadminserver.com:2222\ndns_directadmin_username = username\ndns_directadmin_password = aSuperStrongPassword",
 		"full_plugin_name": "dns-directadmin",
 		"name": "DirectAdmin",
 		"package_name": "certbot-dns-directadmin"


### PR DESCRIPTION
## Problem
  The credentials template for the DirectAdmin DNS plugin used incorrect key names:
  - directadmin_url
  - directadmin_username
  - directadmin_password

  But the certbot-dns-directadmin plugin expects keys prefixed with `dns_directadmin_`:
  - dns_directadmin_url
  - dns_directadmin_username
  - dns_directadmin_password

  This caused certbot to fail with:
  {}: dns_directadmin_url is required

  ## Fix
  Added `dns_` prefix to all three credential key names in the template.

  ## Testing
  Tested locally by building from source — certificate was successfully issued
  after both this fix and the previous fix https://github.com/ZoeyVid/NPMplus/pull/3063.