### PR TITLE
(feat) reduce time for 'chown' process when PUID/PGID != 0

### DIFF
--- a/rootfs/usr/local/bin/start.sh
+++ b/rootfs/usr/local/bin/start.sh
@@ -527,7 +527,8 @@ if [ "$PUID" != "0" ]; then
          /run \
          /tmp \
          -not \( -uid "$PUID" -and -gid "$PGID" \) \
-         -exec chown "$PUID:$PGID" {} \;
+         -print0 \
+         | xargs -0 -P "$(($(nproc)*4))" -n 50 chown "$PUID:$PGID" 
     chown "$PUID:$PGID" /proc/self/fd/2
     if [ "$PHP83" = "true" ]; then
         sed -i "s|;\?user =.*|;user = root|" /data/php/83/php-fpm.d/www.conf
@@ -543,7 +544,7 @@ if [ "$PUID" != "0" ]; then
     fi
     exec su-exec "$PUID:$PGID" launch.sh
 else
-    find /data -not \( -uid 0 -and -gid 0 \) -exec chown 0:0 {} \;
+    find /data -not \( -uid 0 -and -gid 0 \) -print0 | xargs -0 -P "$(($(nproc)*4))" -n 50 chown 0:0
     if [ "$PHP83" = "true" ]; then
         sed -i "s|;user =.*|user = root|" /data/php/83/php-fpm.d/www.conf
         sed -i "s|;group =.*|group = root|" /data/php/83/php-fpm.d/www.conf


### PR DESCRIPTION
I've been experiencing extremely long times for the `chown` process contained in `start.sh` when PUID/PGID are not 0.  This is mentioned/discussed in #1369 

The existing code is inefficient as it iterates through each file one by one and spawns a new `chown` process 
https://github.com/ZoeyVid/NPMplus/blob/a4b7db1a3e906c10ed66c498cd0e28d69630d6a7/rootfs/usr/local/bin/start.sh#L518-L523

My server/host specs are: TrueNAS 25.10, Ryzen 5 1600 AF, 40GB RAM, IronWolf HDDs.  It's likely my HDD (spinning drive) is the bottleneck in this case as there are 2,824 files that are being `chown`ed and maybe because it is ZFS.

I ran 5 trial runs in a container before making changes:

```
docker run --volume /tmp:/data -e TZ=America/New_York --entrypoint=/bin/bash -it zoeyvid/npmplus:latest
time find /usr/local /data /run /tmp  -not \( -uid 568 -and -gid 568 \) -exec chown 568:568 {} \;`
exit, remove container, repeat
```
The times are as follows:
```
Run 1: 11:43.820
Run 2: 12:03.963
Run 3: 12:00.634
Run 4: 11:30.063
Run 5: 12:02.166
Average: 11:52.129
```

I then ran the following instead using `xargs -P 0 -n 50` which passes 50 files per `chown` process on the command line, effectively starting 57 parallel processes. (2,840 / 50)

```
time find /usr/local /data /run /tmp  -not \( -uid 568 -and -gid 568 \) | xargs -P 0 -n 50 chown 568:568
```
```
Run 1: 01:36.199
Run 2: 01:30.601
Run 3: 01:27.925
Run 4: 01:27.520
Run 5: 01:27.500
Average: 01:29.949
```
The performance improvement is significant.  I tried a few different values for `-P` and `-n` and for me at least, these settings are the sweet spot.  `-P 0 -n 30` was the same time (results in 95 processes instead). `-P 8 -n 50` was 4.5 minutes `-P 16 -n 50` was 2.5 minutes. 

This PR adds the above code in and also adds two variables in case an admin needs to override the defaults `-P` and `-n` values in case they are running a very low end setup (slower than mine) that gets bogged down by too many processes being spawned.
`XARGS_CHOWN_MAX_PROCS` (default 0, no limit) and `XARGS_CHOWN_MAX_ARGS` (default 50).

I know @Zoey2936 you mention in #1369 that it takes you less than a minute to startup, but hopefully this will give some relief for some other users who are experiencing an extremely slow startup like I am. 