### PR TITLE
fix: update the Certbot Gandi plugin to fix generate certificate failed

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -195,7 +195,7 @@
 		"credentials": "# Gandi personal access token\ndns_gandi_token=PERSONAL_ACCESS_TOKEN",
 		"full_plugin_name": "dns-gandi",
 		"name": "Gandi Live DNS",
-		"package_name": "certbot-dns-gandi"
+		"package_name": "certbot-dns-gandi-modern"
 	},
 	"gcore": {
 		"credentials": "dns_gcore_apitoken = 0123456789abcdef0123456789abcdef01234567",


### PR DESCRIPTION
Change certbot gandi plugin to certbot-dns-gandi-modern