### PR TITLE
feat: add Bearer token API authentication fallback

### DIFF
--- a/backend/lib/express/jwt-decode.js
+++ b/backend/lib/express/jwt-decode.js
@@ -2,7 +2,9 @@ import Access from "../access.js";
 
 export default () => {
 	return async (req, res, next) => {
-		const token = req.signedCookies?.["__Host-Http-token"] || null;
+		const bearerHeader = req.headers.authorization;
+		const bearerToken = bearerHeader?.startsWith("Bearer ") ? bearerHeader.slice(7) : null;
+		const token = req.signedCookies?.["__Host-Http-token"] || bearerToken || null;
 
 		//if (!token) {
 		//	return res.status(401).json({

--- a/backend/routes/tokens.js
+++ b/backend/routes/tokens.js
@@ -89,7 +89,6 @@ router
 
 			const data = await apiValidator(getValidationSchema("/tokens", "post"), req.body);
 			const result = await internalToken.getTokenFromEmail(data);
-			const { token, ...responseBody } = result;
 
 			if (result.token && result.expires) {
 				res.cookie("__Host-Http-token", result.token, {
@@ -101,7 +100,7 @@ router
 				});
 			}
 
-			res.status(200).send(responseBody);
+			res.status(200).send(result);
 		} catch (err) {
 			debug(logger, `${req.method.toUpperCase()} ${req.originalUrl}: ${err}`);
 			next(err);
@@ -147,7 +146,6 @@ router
 
 			const { challenge_token, code } = await apiValidator(getValidationSchema("/tokens/2fa", "post"), req.body);
 			const result = await internalToken.verify2FA(challenge_token, code);
-			const { token, ...responseBody } = result;
 
 			if (result.token && result.expires) {
 				res.cookie("__Host-Http-token", result.token, {
@@ -159,7 +157,7 @@ router
 				});
 			}
 
-			res.status(200).send(responseBody);
+			res.status(200).send(result);
 		} catch (err) {
 			debug(logger, `${req.method.toUpperCase()} ${req.path}: ${err}`);
 			next(err);


### PR DESCRIPTION
## Summary

Adds support for `Authorization: Bearer <token>` header as a fallback authentication method alongside the existing secure cookie auth.

This enables programmatic API access from:
- **MCP servers** (Model Context Protocol) for AI-assisted management
- **Dashboard widgets** (Homepage, etc.) — ref #2568
- **Automation tools** and scripts
- Any tool that needs API access without browser cookie support

## Changes

- **`backend/lib/express/jwt-decode.js`**: Check `Authorization: Bearer` header as fallback after cookie. Cookies remain the primary and preferred auth method — no change for the web UI.
- **`backend/routes/tokens.js`**: Return the JWT token in the `POST /tokens` and `POST /tokens/2fa` response body (alongside the cookie), so API clients can capture and reuse it.

## Why

Since the move to secure httpOnly cookies (#2568), all third-party integrations that relied on the Bearer token API flow are broken. This includes all three existing MCP servers for NPM ([adamgell](https://github.com/adamgell/nginx-proxy-manager-mcp), [b3nw](https://github.com/b3nw/nginx-proxy-manager-mcp), [VeryBigSad](https://github.com/VeryBigSad/nginx-proxy-manager-mcp)), Homepage dashboard widgets, and custom scripts.

This PR restores API compatibility without reverting the cookie-based security improvements:
- Cookies remain the **primary** auth method (checked first)
- Bearer token is only a **fallback** for programmatic access
- Same JWT, same validation, same Access class — no security downgrade
- Web UI is completely unaffected

## Testing

Tested on NPMplus 2.13.7:
1. `POST /api/tokens` with credentials → returns `{ token, expires }` in body
2. `GET /api/nginx/proxy-hosts` with `Authorization: Bearer <token>` → returns hosts
3. Web UI login via cookies → still works as before
4. MCP server `nginx-proxy-manager-mcp` → authenticates and lists hosts