### PR TITLE
Scope FancyIndex local header/footer directives to enabled hosts (+ module fd-close patch)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,10 @@ RUN git-clone-commit.sh https://github.com/nginx/nginx "$NGINX_VER" /src/nginx &
     git apply /src/zstd-nginx-module/2.patch && \
     git-clone-commit.sh https://github.com/HanadaLee/ngx_http_unzstd_filter_module "$NHUZFM_VER" /src/ngx_http_unzstd_filter_module && \
     git-clone-commit.sh https://github.com/aperezdc/ngx-fancyindex "$NF_VER" /src/ngx-fancyindex && \
+    cd /src/ngx-fancyindex && \
+    wget -q https://patch-diff.githubusercontent.com/raw/aperezdc/ngx-fancyindex/pull/176.patch -O /src/ngx-fancyindex/176.patch && \
+    echo "0b76992c0981e5beda1f158493d0334dcbdfe381348ea0eeeb09123bd9aaa4d3  /src/ngx-fancyindex/176.patch" | sha256sum -c - && \
+    git apply /src/ngx-fancyindex/176.patch && \
     git-clone-commit.sh https://github.com/openresty/headers-more-nginx-module "$HMNM_VER" /src/headers-more-nginx-module && \
     git-clone-commit.sh https://github.com/vision5/ngx_devel_kit "$NDK_VER" /src/ngx_devel_kit && \
     git-clone-commit.sh https://github.com/openresty/lua-nginx-module "$LNM_VER" /src/lua-nginx-module && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,9 +105,9 @@ RUN git-clone-commit.sh https://github.com/nginx/nginx "$NGINX_VER" /src/nginx &
     git-clone-commit.sh https://github.com/HanadaLee/ngx_http_unzstd_filter_module "$NHUZFM_VER" /src/ngx_http_unzstd_filter_module && \
     git-clone-commit.sh https://github.com/aperezdc/ngx-fancyindex "$NF_VER" /src/ngx-fancyindex && \
     cd /src/ngx-fancyindex && \
-    wget -q https://patch-diff.githubusercontent.com/raw/aperezdc/ngx-fancyindex/pull/176.patch -O /src/ngx-fancyindex/176.patch && \
-    echo "0b76992c0981e5beda1f158493d0334dcbdfe381348ea0eeeb09123bd9aaa4d3  /src/ngx-fancyindex/176.patch" | sha256sum -c - && \
-    git apply /src/ngx-fancyindex/176.patch && \
+    wget -q https://patch-diff.githubusercontent.com/raw/aperezdc/ngx-fancyindex/pull/176.patch -O /src/ngx-fancyindex/1.patch && \
+    echo "0b76992c0981e5beda1f158493d0334dcbdfe381348ea0eeeb09123bd9aaa4d3  /src/ngx-fancyindex/1.patch" | sha256sum -c - && \
+    git apply /src/ngx-fancyindex/1.patch && \
     git-clone-commit.sh https://github.com/openresty/headers-more-nginx-module "$HMNM_VER" /src/headers-more-nginx-module && \
     git-clone-commit.sh https://github.com/vision5/ngx_devel_kit "$NDK_VER" /src/ngx_devel_kit && \
     git-clone-commit.sh https://github.com/openresty/lua-nginx-module "$LNM_VER" /src/lua-nginx-module && \


### PR DESCRIPTION
## Summary

Apply the upstream `ngx-fancyindex` fd-leak fix (aperezdc/ngx-fancyindex#176) in the Dockerfile, following the same convention as the other PR patches (download, verify sha256, apply). Per maintainer preference, the FancyIndex configuration stays in the global `http {}` block — the module-level fix alone removes the leak.

## Cause / Trigger

The cause is a missing `ngx_close_file(file.fd)` on the successful local-file read path in `ngx_fancyindex_conf_set_headerfooter()`. The trigger is nginx configuration parsing of each `fancyindex_header ... local` and `fancyindex_footer ... local` directive during reload.

With the directives in the global `http {}` block, every reload leaks +2 fds in the nginx master process regardless of whether any host enables FancyIndex.

## Reproduction Evidence

Observed on live NPMplus containers using `zoeyvid/npmplus:latest` in July 2026:

```text
master fancyindex fd count: 348
after reload #1: 350
after reload #2: 352
```

After about two months of routine reloads, one affected container with observed `nofile=1024` had worker fds near exhaustion (`469 + 469` header/footer handles), at which point nginx logged `accept4() failed (24: No file descriptors available)` and all web traffic failed.

Removing the file-backed directives on a live container stopped the growth completely (three consecutive reloads, +0), which is consistent with the missing-close path being the cause. The one-line upstream patch closes the fd after the read loop, matching the existing error-path cleanup.

## Changes

- Dockerfile: after cloning `/src/ngx-fancyindex`, download the upstream PR patch from `patch-diff.githubusercontent.com`, verify its sha256, and `git apply` it — same pattern as the nginx PR patches above.

The patch can be dropped once the fix lands in a tagged `ngx-fancyindex` release and `NF_VER` is bumped.

## Testing

- Verified the patch applies cleanly to the pinned `NF_VER` source (annotated tag `v0.6.0`, peeled commit `70311f2`) and that the resulting `ngx_close_file(file.fd);` sits inside `ngx_fancyindex_conf_set_headerfooter()`, immediately after the read loop.
- sha256 of the downloaded patch is pinned in the Dockerfile.
- No full Docker image build was run locally; CI is the final check for the build.