### PR TITLE
fix: correct inverted pass_auth logic in proxy_host template

### DIFF
--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -150,7 +150,7 @@
         # Authorization
         auth_basic            "basic access authentication required";
         auth_basic_user_file  {{ filename }};
-        {% if access_list.pass_auth %}
+        {% if not access_list.pass_auth %}
           proxy_set_header Authorization "";
         {% endif %}
       {% endif %}


### PR DESCRIPTION
### Summary
Fixes an issue where enabling **"Pass Auth to Upstream"** (`pass_auth`) in an Access List actually strips the `Authorization` header instead of forwarding it to the upstream host.

### Root Cause
In `backend/templates/proxy_host.conf`, the condition `{% if access_list.pass_auth %}` was missing `not`. 
When `pass_auth` was set to `true`, it executed `proxy_set_header Authorization "";`, which inverted the expected behavior and caused infinite 401 authentication loops on upstream services (such as WebDAV).

### Fix
Updated the condition to `{% if not access_list.pass_auth %}` so that the `Authorization` header is cleared ONLY when `pass_auth` is disabled (`false`).

### Historical Context
This regression was introduced in commit `8b2bc2845e7b5ee90ec920fbc8c34dabb785a066` during template refactoring, where the boolean condition omitted `not`.